### PR TITLE
Add Throwing Initializer, Remove `Validated2` and `Validated3`

### DIFF
--- a/Tests/ValidatedTests.swift
+++ b/Tests/ValidatedTests.swift
@@ -195,9 +195,12 @@ class ValidatedTests: XCTestCase {
         do {
             _ = try NonEmptyString("").value
         } catch let error as ValidatorError {
-            // Check that error returns validator metatype and wrapper value
             XCTAssertTrue(error.validator == Not<EmptyStringValidator>.self)
             XCTAssertTrue(error.wrapperValue as! String == "")
+            XCTAssertEqual(
+                error.description,
+                "Value: '' <String>, failed validation of Validator: Not<EmptyStringValidator>"
+            )
         } catch {}
 
         // Create a non-empty string

--- a/Tests/ValidatedTests.swift
+++ b/Tests/ValidatedTests.swift
@@ -21,11 +21,11 @@ class ValidatedTests: XCTestCase {
         // Define a type for a non-empty string
         typealias NonEmptyString = Validated<String, Not<EmptyStringValidator>>
         // Create an empty string
-        let valueNotValidated = NonEmptyString("")?.value
+        let valueNotValidated = NonEmptyString(value: "")?.value
         XCTAssertNil(valueNotValidated)
 
         // Create a non-empty string
-        let valueValidated = NonEmptyString("This is OK.")?.value
+        let valueValidated = NonEmptyString(value: "This is OK.")?.value
         XCTAssertEqual(valueValidated, "This is OK.")
     }
 
@@ -33,10 +33,10 @@ class ValidatedTests: XCTestCase {
         // Define a type for a non-empty collection
         typealias NonEmptyListOfStrings = Validated<[String], Not<EmptyCollectionValidator<[String]>>>
         // Create an empty list of strings
-        let valueNotValidated = NonEmptyListOfStrings([])?.value
+        let valueNotValidated = NonEmptyListOfStrings(value: [])?.value
         XCTAssertNil(valueNotValidated)
 
-        let valueValidated = NonEmptyListOfStrings(["A", "B"])?.value
+        let valueValidated = NonEmptyListOfStrings(value: ["A", "B"])?.value
         XCTAssertEqual(valueValidated!, ["A", "B"])
     }
 
@@ -44,10 +44,10 @@ class ValidatedTests: XCTestCase {
         // Define a type for an array of ints that has a sum larger 20
         typealias SumLarger20Array = Validated<[Int], SumLarger20Validator>
 
-        let valueNotValidated = SumLarger20Array([8,8])?.value
+        let valueNotValidated = SumLarger20Array(value: [8,8])?.value
         XCTAssertNil(valueNotValidated)
 
-        let valueValidated = SumLarger20Array([8,8,8])?.value
+        let valueValidated = SumLarger20Array(value: [8,8,8])?.value
         XCTAssertEqual(valueValidated!, [8,8,8])
     }
 
@@ -57,10 +57,10 @@ class ValidatedTests: XCTestCase {
         // Define a type for a collection with more than 10 elements
         typealias MoreThan10ElementsIntArray = Validated<[Int], CountGreater10Validator<[Int]>>
 
-        let valueNotValidated = MoreThan10ElementsIntArray([1,2,3,4,5,6])?.value
+        let valueNotValidated = MoreThan10ElementsIntArray(value: [1,2,3,4,5,6])?.value
         XCTAssertNil(valueNotValidated)
 
-        let valueValidated = MoreThan10ElementsIntArray([1,2,3,4,5,6,7,8,9,10,11])?.value
+        let valueValidated = MoreThan10ElementsIntArray(value: [1,2,3,4,5,6,7,8,9,10,11])?.value
         XCTAssertEqual(valueValidated!, [1,2,3,4,5,6,7,8,9,10,11])
     }
 
@@ -71,66 +71,66 @@ class ValidatedTests: XCTestCase {
         typealias LoggedInUser = Validated<User, LoggedInValidator>
 
         let valueNotValidated = LoggedInUser(
-            User(username: "User", loggedIn: false)
+            value: User(username: "User", loggedIn: false)
         )?.value
         XCTAssertNil(valueNotValidated)
 
         let valueValidated = LoggedInUser(
-            User(username: "User", loggedIn: true)
+            value: User(username: "User", loggedIn: true)
         )?.value
         XCTAssertEqual(valueValidated?.username, "User")
     }
 
-    // MARK: Validate2 Tests
+    // MARK: 2 Validator Test
 
     func testValidatesEmptyStringAndAllCaps1() {
         // Define a type for a non-empty all caps latin string
         typealias AllCapsNonEmptyString =
-            Validated2<String, Not<EmptyStringValidator>, AllCapsLatinStringValidator>
+            Validated<String, And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>>
 
         // Create an empty string
-        let valueNotValidated = AllCapsNonEmptyString("")?.value
+        let valueNotValidated = AllCapsNonEmptyString(value: "")?.value
         XCTAssertNil(valueNotValidated)
 
         // Create a string with lowercase letters
-        let valueNotValidated2 = AllCapsNonEmptyString("xYZcF")?.value
+        let valueNotValidated2 = AllCapsNonEmptyString(value: "xYZcF")?.value
         XCTAssertNil(valueNotValidated2)
 
         // Create an all caps string
-        let valueValidated = AllCapsNonEmptyString("XYZCF")?.value
+        let valueValidated = AllCapsNonEmptyString(value: "XYZCF")?.value
         XCTAssertEqual(valueValidated, "XYZCF")
     }
 
     func testValidatesCountGreater10AndSumLarger20() {
         typealias MoreThan10ElementsWithSumGreater20 =
-            Validated2<[Int], CountGreater10Validator<[Int]>, SumLarger20Validator>
+            Validated<[Int], And<CountGreater10Validator<[Int]>, SumLarger20Validator>>
 
-        let valueNotValidated = MoreThan10ElementsWithSumGreater20([100,2,400,5,6])?.value
+        let valueNotValidated = MoreThan10ElementsWithSumGreater20(value: [100,2,400,5,6])?.value
         XCTAssertNil(valueNotValidated)
 
         let valueNotValidated2 = MoreThan10ElementsWithSumGreater20(
-            [1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+            value: [1,1,1,1,1,1,1,1,1,1,1,1,1,1]
         )?.value
         XCTAssertNil(valueNotValidated2)
 
         let valueValidated = MoreThan10ElementsWithSumGreater20(
-            [100,1,1,1,1,1,1,1,1,1,1,1,1,100]
+            value: [100,1,1,1,1,1,1,1,1,1,1,1,1,100]
         )?.value
         XCTAssertEqual(valueValidated!, [100,1,1,1,1,1,1,1,1,1,1,1,1,100])
     }
 
-    // MARK: Validate3 Tests
+    // MARK: 3 Validator Test
 
     func testValidatesEmptyStringAndAllCapsContainsYorZ() {
         typealias AllCapsNonEmptyStringWithYorZ =
-            Validated3<String, Not<EmptyStringValidator>, AllCapsLatinStringValidator, ContainsYorZ>
+            Validated<String, And<And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>, ContainsYorZ>>
 
         // Create a non-complying string
-        let valueNotValidated = AllCapsNonEmptyStringWithYorZ("ABCDEF")?.value
+        let valueNotValidated = AllCapsNonEmptyStringWithYorZ(value: "ABCDEF")?.value
         XCTAssertNil(valueNotValidated)
 
         // Create a compying string
-        let valueValidated = AllCapsNonEmptyStringWithYorZ("ABCDEFY")?.value
+        let valueValidated = AllCapsNonEmptyStringWithYorZ(value: "ABCDEFY")?.value
         XCTAssertEqual(valueValidated, "ABCDEFY")
     }
     
@@ -142,15 +142,15 @@ class ValidatedTests: XCTestCase {
             Validated<String, And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>>
 
         // Create an empty string
-        let valueNotValidated = AllCapsNonEmptyString("")?.value
+        let valueNotValidated = AllCapsNonEmptyString(value: "")?.value
         XCTAssertNil(valueNotValidated)
 
         // Create a string with lowercase letters
-        let valueNotValidated2 = AllCapsNonEmptyString("xYZcF")?.value
+        let valueNotValidated2 = AllCapsNonEmptyString(value: "xYZcF")?.value
         XCTAssertNil(valueNotValidated2)
 
         // Create an all caps string
-        let valueValidated = AllCapsNonEmptyString("XYZCF")?.value
+        let valueValidated = AllCapsNonEmptyString(value: "XYZCF")?.value
         XCTAssertEqual(valueValidated, "XYZCF")
     }
     
@@ -160,15 +160,15 @@ class ValidatedTests: XCTestCase {
             Validated<String, Or<EmptyStringValidator, AllCapsLatinStringValidator>>
         
         // Create an empty string
-        let valueValidated1 = AllCapsOrEmptyString("")?.value
+        let valueValidated1 = AllCapsOrEmptyString(value: "")?.value
         XCTAssertEqual(valueValidated1, "")
         
         // Create a string with lowercase letters
-        let valueNotValidated = AllCapsOrEmptyString("xYZcF")?.value
+        let valueNotValidated = AllCapsOrEmptyString(value: "xYZcF")?.value
         XCTAssertNil(valueNotValidated)
         
         // Create an all caps string
-        let valueValidated2 = AllCapsOrEmptyString("XYZCF")?.value
+        let valueValidated2 = AllCapsOrEmptyString(value: "XYZCF")?.value
         XCTAssertEqual(valueValidated2, "XYZCF")
     }
     
@@ -178,12 +178,30 @@ class ValidatedTests: XCTestCase {
             Validated<String, Not<EmptyStringValidator>>
         
         // Create an empty string
-        let valueNotValidated = AllCapsNonEmptyString("")?.value
+        let valueNotValidated = AllCapsNonEmptyString(value: "")?.value
         XCTAssertNil(valueNotValidated)
         
         // Create an all caps string
-        let valueValidated = AllCapsNonEmptyString("abC")?.value
+        let valueValidated = AllCapsNonEmptyString(value: "abC")?.value
         XCTAssertEqual(valueValidated, "abC")
     }
 
+    // MARK: Error Handling Tests
+
+    func testThrowingInitializer() {
+        // Define a type for a non-empty string
+        typealias NonEmptyString = Validated<String, Not<EmptyStringValidator>>
+        // Create an empty string
+        do {
+            _ = try NonEmptyString("").value
+        } catch let error as ValidatorError {
+            // Check that error returns validator metatype and wrapper value
+            XCTAssertTrue(error.validator == Not<EmptyStringValidator>.self)
+            XCTAssertTrue(error.wrapperValue as! String == "")
+        } catch {}
+
+        // Create a non-empty string
+        let valueValidated = try! NonEmptyString("This is OK.").value
+        XCTAssertEqual(valueValidated, "This is OK.")
+    }
 }

--- a/Validated.xcodeproj/xcshareddata/xcschemes/Validated iOS.xcscheme
+++ b/Validated.xcodeproj/xcshareddata/xcschemes/Validated iOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Validated/Validated.swift
+++ b/Validated/Validated.swift
@@ -1,10 +1,8 @@
-//
 //  Validated.swift
 //  Validated
 //
 //  Created by Benji Encz on 2/24/16.
 //  Copyright © 2016 Benjamin Encz. All rights reserved.
-//
 
 /// This protocol needs to be implemented in order to add a requirement to
 /// a wrapped type.
@@ -23,7 +21,7 @@ public protocol Validator {
     /// Validates if a value of the wrapped type fullfills the requirements of the
     /// wrapper type.
     ///
-    /// - parameter validate: An instance of the `WrappedType`
+    /// - parameter validate: An instance of the `WrappedType`  
     /// - returns: A `Bool` indicating success(`true`)/failure(`false`) of the validation
     static func validate(value: WrappedType) -> Bool
 }
@@ -60,41 +58,12 @@ public struct Validated<WrapperType, V: Validator where V.WrappedType == Wrapper
                 validator: V.self)
         }
 
-/// Wraps a type together with two validators. Provides a failable initializer
-/// that will only return a value of `Validated` if the provided `WrapperType` value
-/// fulfills the requirements of both specified `Validator` types.
-public struct Validated2<
-    WrapperType,
-    V1: Validator,
-    V2: Validator where
-        V1.WrappedType == WrapperType,
-        V2.WrappedType == WrapperType> {
-    /// The value that passes the two provided `Validator`s.
-    public let value: WrapperType
-
-    /// Failible initializer that will only succeed if the provided value fulfills the requirements specified by the `Validator`s.
-    public init?(_ value: WrapperType) {
-        guard V1.validate(value) && V2.validate(value) else { return nil }
         self.value = value
     }
-}
-
-/// Wraps a type together with three validators. Provides a failable initializer
-/// that will only return a value of `Validated` if the provided `WrapperType` value
-/// fulfills the requirements of all three specified `Validator` types.
-public struct Validated3<
-    WrapperType,
-    V1: Validator,
-    V2: Validator,
-    V3: Validator where
-        V1.WrappedType == WrapperType,
-        V2.WrappedType == WrapperType,
-        V3.WrappedType == WrapperType> {
-    /// The value that passes the three provided `Validator`s.
-    public let value: WrapperType
 
     /// Failible initializer that will only succeed if the provided value fulfills the requirements specified by the `Validator`.
     public init?(value: WrapperType) {
+        try? self.init(value)
     }
 }
 


### PR DESCRIPTION
This PR adds the throwing initializer discussed in #4. It also preserves the failable initializer that is now available as an overload. Since it seems that the throwing initializer is more popular, the failable one requires clients to specify the `value` argument name.

Additionally this PR removes `Validated2` and `Validated3` as suggested as part of #3. 
