### PR TITLE
tweaking api and updating to swift 3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "Validated"
+)

--- a/Sources/Validated.swift
+++ b/Sources/Validated.swift
@@ -10,20 +10,20 @@
 /// }
 /// ~~~
 public protocol Validator {
-    typealias WrappedType
+    associatedtype WrappedType
 
     /// Validates if a value of the wrapped type fullfills the requirements of the
     /// wrapper type.
     ///
-    /// - parameter validate: An instance of the `WrappedType`  
+    /// - parameter validate: An instance of the `WrappedType`
     /// - returns: A `Bool` indicating success(`true`)/failure(`false`) of the validation
     static func validate(value: WrappedType) -> Bool
 }
 
 
-/// Error that is thrown when a validation fails. Proivdes the validator type and 
+/// Error that is thrown when a validation fails. Proivdes the validator type and
 /// the value that failed validation
-public struct ValidatorError: ErrorType, CustomStringConvertible {
+public struct ValidatorError: ErrorProtocol, CustomStringConvertible {
     /// The value that failed validation.
     public let wrapperValue: Any
     /// Type of a specific `Validator`. `Any` is used because `Validator` has associated type requirements.
@@ -37,15 +37,15 @@ public struct ValidatorError: ErrorType, CustomStringConvertible {
 /// Wraps a type together with one validator. Provides a failable initializer
 /// that will only return a value of `Validated` if the provided `WrapperType` value
 /// fulfills the requirements of the specified `Validator`.
-public struct Validated<WrapperType, V: Validator where V.WrappedType == WrapperType> {
+public struct Validated<V: Validator> {
     /// The value that passes the defined `Validator`.
     ///
     /// If you are able to access this property; it means the wrappedType passes the validator.
-    public let value: WrapperType
+    public let value: V.WrappedType
 
-    /// Throwing initializer that will *not* throw an error if the provided value fulfills the requirements 
+    /// Throwing initializer that will *not* throw an error if the provided value fulfills the requirements
     /// specified by the `Validator`.
-    public init(_ value: WrapperType) throws {
+    public init(_ value: V.WrappedType) throws {
         guard V.validate(value) else {
             throw ValidatorError(
                 wrapperValue: value,
@@ -56,7 +56,7 @@ public struct Validated<WrapperType, V: Validator where V.WrappedType == Wrapper
     }
 
     /// Failible initializer that will only succeed if the provided value fulfills the requirements specified by the `Validator`.
-    public init?(value: WrapperType) {
+    public init?(value: V.WrappedType) {
         try? self.init(value)
     }
 }
@@ -65,7 +65,7 @@ public struct Validated<WrapperType, V: Validator where V.WrappedType == Wrapper
 public struct And<
     V1: Validator,
     V2: Validator where
-        V1.WrappedType == V2.WrappedType>: Validator {
+V1.WrappedType == V2.WrappedType>: Validator {
     public static func validate(value: V1.WrappedType) -> Bool {
         return V1.validate(value) && V2.validate(value)
     }
@@ -75,7 +75,7 @@ public struct And<
 public struct Or<
     V1: Validator,
     V2: Validator where
-        V1.WrappedType == V2.WrappedType>: Validator {
+V1.WrappedType == V2.WrappedType>: Validator {
     public static func validate(value: V1.WrappedType) -> Bool {
         return V1.validate(value) || V2.validate(value)
     }

--- a/Sources/Validated.swift
+++ b/Sources/Validated.swift
@@ -22,7 +22,7 @@ public protocol Validator {
     ///
     /// - parameter validate: An instance of the `WrappedType`
     /// - returns: A `Bool` indicating success(`true`)/failure(`false`) of the validation
-    static func validate(value: WrappedType) -> Bool
+    static func validate(_ value: WrappedType) -> Bool
 }
 
 
@@ -42,15 +42,15 @@ public struct ValidatorError: ErrorProtocol, CustomStringConvertible {
 /// Wraps a type together with one validator. Provides a failable initializer
 /// that will only return a value of `Validated` if the provided `WrapperType` value
 /// fulfills the requirements of the specified `Validator`.
-public struct Validated<V: Validator> {
+public struct Validated<WrapperType, V: Validator where V.WrappedType == WrapperType> {
     /// The value that passes the defined `Validator`.
     ///
     /// If you are able to access this property; it means the wrappedType passes the validator.
-    public let value: V.WrappedType
+    public let value: WrapperType
 
     /// Throwing initializer that will *not* throw an error if the provided value fulfills the requirements
     /// specified by the `Validator`.
-    public init(_ value: V.WrappedType) throws {
+    public init(_ value: WrapperType) throws {
         guard V.validate(value) else {
             throw ValidatorError(
                 wrapperValue: value,
@@ -61,7 +61,7 @@ public struct Validated<V: Validator> {
     }
 
     /// Failible initializer that will only succeed if the provided value fulfills the requirements specified by the `Validator`.
-    public init?(value: V.WrappedType) {
+    public init?(value: WrapperType) {
         try? self.init(value)
     }
 }
@@ -71,7 +71,7 @@ public struct And<
     V1: Validator,
     V2: Validator where
 V1.WrappedType == V2.WrappedType>: Validator {
-    public static func validate(value: V1.WrappedType) -> Bool {
+    public static func validate(_ value: V1.WrappedType) -> Bool {
         return V1.validate(value) && V2.validate(value)
     }
 }
@@ -81,14 +81,14 @@ public struct Or<
     V1: Validator,
     V2: Validator where
 V1.WrappedType == V2.WrappedType>: Validator {
-    public static func validate(value: V1.WrappedType) -> Bool {
+    public static func validate(_ value: V1.WrappedType) -> Bool {
         return V1.validate(value) || V2.validate(value)
     }
 }
 
 /// Validator wrapper which is valid when `V1` validated to `false`.
 public struct Not<V1: Validator>: Validator {
-    public static func validate(value: V1.WrappedType) -> Bool {
+    public static func validate(_ value: V1.WrappedType) -> Bool {
         return !V1.validate(value)
     }
 }

--- a/Sources/Validated.swift
+++ b/Sources/Validated.swift
@@ -1,3 +1,8 @@
+#if swift(>=3.0)
+#else
+    public typealias ErrorProtocol = ErrorType
+#endif
+
 /// This protocol needs to be implemented in order to add a requirement to
 /// a wrapped type.
 /// Implementers receive the wrapped type and need to determine if its values

--- a/Tests/ValidatedTests.swift
+++ b/Tests/ValidatedTests.swift
@@ -11,7 +11,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesEmptyString() {
         // Define a type for a non-empty string
-        typealias NonEmptyString = Validated<String, Not<EmptyStringValidator>>
+        typealias NonEmptyString = Validated<Not<EmptyStringValidator>>
         // Create an empty string
         let valueNotValidated = NonEmptyString(value: "")?.value
         XCTAssertNil(valueNotValidated)
@@ -23,7 +23,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesAnyEmptyCollection() {
         // Define a type for a non-empty collection
-        typealias NonEmptyListOfStrings = Validated<[String], Not<EmptyCollectionValidator<[String]>>>
+        typealias NonEmptyListOfStrings = Validated<Not<EmptyCollectionValidator<[String]>>>
         // Create an empty list of strings
         let valueNotValidated = NonEmptyListOfStrings(value: [])?.value
         XCTAssertNil(valueNotValidated)
@@ -34,7 +34,7 @@ class ValidatedTests: XCTestCase {
 
     func testSumLarger20() {
         // Define a type for an array of ints that has a sum larger 20
-        typealias SumLarger20Array = Validated<[Int], SumLarger20Validator>
+        typealias SumLarger20Array = Validated<SumLarger20Validator>
 
         let valueNotValidated = SumLarger20Array(value: [8,8])?.value
         XCTAssertNil(valueNotValidated)
@@ -47,7 +47,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesCountGreater10() {
         // Define a type for a collection with more than 10 elements
-        typealias MoreThan10ElementsIntArray = Validated<[Int], CountGreater10Validator<[Int]>>
+        typealias MoreThan10ElementsIntArray = Validated<CountGreater10Validator<[Int]>>
 
         let valueNotValidated = MoreThan10ElementsIntArray(value: [1,2,3,4,5,6])?.value
         XCTAssertNil(valueNotValidated)
@@ -60,7 +60,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesLoggedInUser() {
         // Define a type for a logged in user
-        typealias LoggedInUser = Validated<User, LoggedInValidator>
+        typealias LoggedInUser = Validated<LoggedInValidator>
 
         let valueNotValidated = LoggedInUser(
             value: User(username: "User", loggedIn: false)
@@ -78,7 +78,7 @@ class ValidatedTests: XCTestCase {
     func testValidatesEmptyStringAndAllCaps1() {
         // Define a type for a non-empty all caps latin string
         typealias AllCapsNonEmptyString =
-            Validated<String, And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>>
+            Validated<And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>>
 
         // Create an empty string
         let valueNotValidated = AllCapsNonEmptyString(value: "")?.value
@@ -95,7 +95,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesCountGreater10AndSumLarger20() {
         typealias MoreThan10ElementsWithSumGreater20 =
-            Validated<[Int], And<CountGreater10Validator<[Int]>, SumLarger20Validator>>
+            Validated<And<CountGreater10Validator<[Int]>, SumLarger20Validator>>
 
         let valueNotValidated = MoreThan10ElementsWithSumGreater20(value: [100,2,400,5,6])?.value
         XCTAssertNil(valueNotValidated)
@@ -115,7 +115,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesEmptyStringAndAllCapsContainsYorZ() {
         typealias AllCapsNonEmptyStringWithYorZ =
-            Validated<String, And<And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>, ContainsYorZ>>
+            Validated<And<And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>, ContainsYorZ>>
 
         // Create a non-complying string
         let valueNotValidated = AllCapsNonEmptyStringWithYorZ(value: "ABCDEF")?.value
@@ -131,7 +131,7 @@ class ValidatedTests: XCTestCase {
     func testValidatesEmptyStringAndAllCaps2() {
         // Define a type for a non-empty all caps latin string
         typealias AllCapsNonEmptyString =
-            Validated<String, And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>>
+            Validated<And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>>
 
         // Create an empty string
         let valueNotValidated = AllCapsNonEmptyString(value: "")?.value
@@ -149,7 +149,7 @@ class ValidatedTests: XCTestCase {
     func testValidatesEmptyStringOrAllCaps() {
         // Define a type for an empty or all caps latin string
         typealias AllCapsOrEmptyString =
-            Validated<String, Or<EmptyStringValidator, AllCapsLatinStringValidator>>
+            Validated<Or<EmptyStringValidator, AllCapsLatinStringValidator>>
         
         // Create an empty string
         let valueValidated1 = AllCapsOrEmptyString(value: "")?.value
@@ -167,7 +167,7 @@ class ValidatedTests: XCTestCase {
     func testValidatesNonEmpty() {
         // Define a type for a non-empty string
         typealias AllCapsNonEmptyString =
-            Validated<String, Not<EmptyStringValidator>>
+            Validated<Not<EmptyStringValidator>>
         
         // Create an empty string
         let valueNotValidated = AllCapsNonEmptyString(value: "")?.value
@@ -182,7 +182,7 @@ class ValidatedTests: XCTestCase {
 
     func testThrowingInitializer() {
         // Define a type for a non-empty string
-        typealias NonEmptyString = Validated<String, Not<EmptyStringValidator>>
+        typealias NonEmptyString = Validated<Not<EmptyStringValidator>>
         // Create an empty string
         do {
             _ = try NonEmptyString("").value

--- a/Tests/ValidatedTests.swift
+++ b/Tests/ValidatedTests.swift
@@ -11,7 +11,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesEmptyString() {
         // Define a type for a non-empty string
-        typealias NonEmptyString = Validated<Not<EmptyStringValidator>>
+        typealias NonEmptyString = Validated<String, Not<EmptyStringValidator>>
         // Create an empty string
         let valueNotValidated = NonEmptyString(value: "")?.value
         XCTAssertNil(valueNotValidated)
@@ -23,7 +23,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesAnyEmptyCollection() {
         // Define a type for a non-empty collection
-        typealias NonEmptyListOfStrings = Validated<Not<EmptyCollectionValidator<[String]>>>
+        typealias NonEmptyListOfStrings = Validated<[String], Not<EmptyCollectionValidator<[String]>>>
         // Create an empty list of strings
         let valueNotValidated = NonEmptyListOfStrings(value: [])?.value
         XCTAssertNil(valueNotValidated)
@@ -34,7 +34,7 @@ class ValidatedTests: XCTestCase {
 
     func testSumLarger20() {
         // Define a type for an array of ints that has a sum larger 20
-        typealias SumLarger20Array = Validated<SumLarger20Validator>
+        typealias SumLarger20Array = Validated<[Int], SumLarger20Validator>
 
         let valueNotValidated = SumLarger20Array(value: [8,8])?.value
         XCTAssertNil(valueNotValidated)
@@ -47,7 +47,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesCountGreater10() {
         // Define a type for a collection with more than 10 elements
-        typealias MoreThan10ElementsIntArray = Validated<CountGreater10Validator<[Int]>>
+        typealias MoreThan10ElementsIntArray = Validated<[Int], CountGreater10Validator<[Int]>>
 
         let valueNotValidated = MoreThan10ElementsIntArray(value: [1,2,3,4,5,6])?.value
         XCTAssertNil(valueNotValidated)
@@ -60,7 +60,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesLoggedInUser() {
         // Define a type for a logged in user
-        typealias LoggedInUser = Validated<LoggedInValidator>
+        typealias LoggedInUser = Validated<User, LoggedInValidator>
 
         let valueNotValidated = LoggedInUser(
             value: User(username: "User", loggedIn: false)
@@ -78,7 +78,7 @@ class ValidatedTests: XCTestCase {
     func testValidatesEmptyStringAndAllCaps1() {
         // Define a type for a non-empty all caps latin string
         typealias AllCapsNonEmptyString =
-            Validated<And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>>
+            Validated<String, And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>>
 
         // Create an empty string
         let valueNotValidated = AllCapsNonEmptyString(value: "")?.value
@@ -95,7 +95,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesCountGreater10AndSumLarger20() {
         typealias MoreThan10ElementsWithSumGreater20 =
-            Validated<And<CountGreater10Validator<[Int]>, SumLarger20Validator>>
+            Validated<[Int], And<CountGreater10Validator<[Int]>, SumLarger20Validator>>
 
         let valueNotValidated = MoreThan10ElementsWithSumGreater20(value: [100,2,400,5,6])?.value
         XCTAssertNil(valueNotValidated)
@@ -115,7 +115,7 @@ class ValidatedTests: XCTestCase {
 
     func testValidatesEmptyStringAndAllCapsContainsYorZ() {
         typealias AllCapsNonEmptyStringWithYorZ =
-            Validated<And<And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>, ContainsYorZ>>
+            Validated<String, And<And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>, ContainsYorZ>>
 
         // Create a non-complying string
         let valueNotValidated = AllCapsNonEmptyStringWithYorZ(value: "ABCDEF")?.value
@@ -131,7 +131,7 @@ class ValidatedTests: XCTestCase {
     func testValidatesEmptyStringAndAllCaps2() {
         // Define a type for a non-empty all caps latin string
         typealias AllCapsNonEmptyString =
-            Validated<And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>>
+            Validated<String, And<Not<EmptyStringValidator>, AllCapsLatinStringValidator>>
 
         // Create an empty string
         let valueNotValidated = AllCapsNonEmptyString(value: "")?.value
@@ -149,7 +149,7 @@ class ValidatedTests: XCTestCase {
     func testValidatesEmptyStringOrAllCaps() {
         // Define a type for an empty or all caps latin string
         typealias AllCapsOrEmptyString =
-            Validated<Or<EmptyStringValidator, AllCapsLatinStringValidator>>
+            Validated<String, Or<EmptyStringValidator, AllCapsLatinStringValidator>>
         
         // Create an empty string
         let valueValidated1 = AllCapsOrEmptyString(value: "")?.value
@@ -167,7 +167,7 @@ class ValidatedTests: XCTestCase {
     func testValidatesNonEmpty() {
         // Define a type for a non-empty string
         typealias AllCapsNonEmptyString =
-            Validated<Not<EmptyStringValidator>>
+            Validated<String, Not<EmptyStringValidator>>
         
         // Create an empty string
         let valueNotValidated = AllCapsNonEmptyString(value: "")?.value
@@ -182,7 +182,7 @@ class ValidatedTests: XCTestCase {
 
     func testThrowingInitializer() {
         // Define a type for a non-empty string
-        typealias NonEmptyString = Validated<Not<EmptyStringValidator>>
+        typealias NonEmptyString = Validated<String, Not<EmptyStringValidator>>
         // Create an empty string
         do {
             _ = try NonEmptyString("").value

--- a/Tests/helpers/CustomTypeExample.swift
+++ b/Tests/helpers/CustomTypeExample.swift
@@ -17,7 +17,7 @@ struct User {
 
 struct LoggedInValidator: Validator {
 
-    static func validate(value: User) -> Bool {
+    static func validate(_ value: User) -> Bool {
         return value.loggedIn
     }
 

--- a/Tests/helpers/ExampleValidators.swift
+++ b/Tests/helpers/ExampleValidators.swift
@@ -8,6 +8,11 @@
 
 @testable import Validated
 
+#if swift(>=3.0)
+#else
+    public typealias Collection = CollectionType
+#endif
+
 // Example validators that are used throughout the unit tests. These should also be a good starting point for your custom `Validator` types.
 
 struct EmptyStringValidator: Validator {
@@ -32,6 +37,12 @@ struct ContainsYorZ: Validator {
     }
 }
 
+struct SumLarger20Validator: Validator {
+    static func validate(value: [Int]) -> Bool {
+        return value.reduce(0, combine: +) > 20
+    }
+}
+
 struct EmptyCollectionValidator<T: Collection>: Validator {
     static func validate(value: T) -> Bool {
         return value.isEmpty
@@ -41,11 +52,5 @@ struct EmptyCollectionValidator<T: Collection>: Validator {
 struct CountGreater10Validator<T: Collection>: Validator {
     static func validate(value: T) -> Bool {
         return value.count > 10
-    }
-}
-
-struct SumLarger20Validator: Validator {
-    static func validate(value: [Int]) -> Bool {
-        return value.reduce(0, combine: +) > 20
     }
 }

--- a/Tests/helpers/ExampleValidators.swift
+++ b/Tests/helpers/ExampleValidators.swift
@@ -32,13 +32,13 @@ struct ContainsYorZ: Validator {
     }
 }
 
-struct EmptyCollectionValidator<T: CollectionType>: Validator {
+struct EmptyCollectionValidator<T: Collection>: Validator {
     static func validate(value: T) -> Bool {
         return value.isEmpty
     }
 }
 
-struct CountGreater10Validator<T: CollectionType>: Validator {
+struct CountGreater10Validator<T: Collection>: Validator {
     static func validate(value: T) -> Bool {
         return value.count > 10
     }

--- a/Tests/helpers/ExampleValidators.swift
+++ b/Tests/helpers/ExampleValidators.swift
@@ -16,13 +16,13 @@
 // Example validators that are used throughout the unit tests. These should also be a good starting point for your custom `Validator` types.
 
 struct EmptyStringValidator: Validator {
-    static func validate(value: String) -> Bool {
+    static func validate(_ value: String) -> Bool {
         return value.isEmpty
     }
 }
 
 struct AllCapsLatinStringValidator: Validator {
-    static func validate(value: String) -> Bool {
+    static func validate(_ value: String) -> Bool {
         return value.characters.reduce(true) { accumulator, character in
             return accumulator && ("A"..."Z").contains(character)
         }
@@ -30,7 +30,7 @@ struct AllCapsLatinStringValidator: Validator {
 }
 
 struct ContainsYorZ: Validator {
-    static func validate(value: String) -> Bool {
+    static func validate(_ value: String) -> Bool {
         return value.characters.reduce(false) { accumulator, character in
             return accumulator || ("Y"..."Z").contains(character)
         }
@@ -38,19 +38,19 @@ struct ContainsYorZ: Validator {
 }
 
 struct SumLarger20Validator: Validator {
-    static func validate(value: [Int]) -> Bool {
+    static func validate(_ value: [Int]) -> Bool {
         return value.reduce(0, combine: +) > 20
     }
 }
 
 struct EmptyCollectionValidator<T: Collection>: Validator {
-    static func validate(value: T) -> Bool {
+    static func validate(_ value: T) -> Bool {
         return value.isEmpty
     }
 }
 
 struct CountGreater10Validator<T: Collection>: Validator {
-    static func validate(value: T) -> Bool {
+    static func validate(_ value: T) -> Bool {
         return value.count > 10
     }
 }

--- a/Validated.podspec
+++ b/Validated.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Validated"
-  s.version          = "2.0.0"
+  s.version          = "3.0.0"
   s.summary          = "A Swift μ-Library for Somewhat Dependent Types"
   s.description      = <<-DESC
                         Validated is a μ-library (~50 Source Lines of Code) that allows you make better use of Swift's type system
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target    = '9.0'
   s.watchos.deployment_target = '2.0'
   s.requires_arc = true
-  s.source_files     = 'Validated/**/*.swift'
+  s.source_files     = 'Sources/**/*.swift'
 end

--- a/Validated.xcodeproj/project.pbxproj
+++ b/Validated.xcodeproj/project.pbxproj
@@ -8,7 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		25C79AA81C7EA40B00F76B49 /* Validated.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25C79A9D1C7EA40B00F76B49 /* Validated.framework */; };
-		25C79AB81C7EA5A800F76B49 /* Validated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C79AB71C7EA5A800F76B49 /* Validated.swift */; };
+		806ACA8F1CB8CF1000A06939 /* Validated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806ACA8E1CB8CF1000A06939 /* Validated.swift */; };
+		806ACA901CB8CF1000A06939 /* Validated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806ACA8E1CB8CF1000A06939 /* Validated.swift */; };
+		806ACA911CB8CF1000A06939 /* Validated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806ACA8E1CB8CF1000A06939 /* Validated.swift */; };
+		806ACA921CB8CF1000A06939 /* Validated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806ACA8E1CB8CF1000A06939 /* Validated.swift */; };
 		BC9786571C84A2D900A68A31 /* Validated.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC703501C8497B500880C4C /* Validated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BC9786581C84A2EC00A68A31 /* Validated.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC703501C8497B500880C4C /* Validated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BC9786671C84A44D00A68A31 /* Validated.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC703501C8497B500880C4C /* Validated.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -31,7 +34,7 @@
 /* Begin PBXFileReference section */
 		25C79A9D1C7EA40B00F76B49 /* Validated.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Validated.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25C79AA71C7EA40B00F76B49 /* ValidatedTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ValidatedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		25C79AB71C7EA5A800F76B49 /* Validated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Validated.swift; sourceTree = "<group>"; };
+		806ACA8E1CB8CF1000A06939 /* Validated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Validated.swift; path = Sources/Validated.swift; sourceTree = SOURCE_ROOT; };
 		BC97865E1C84A30C00A68A31 /* Validated.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Validated.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC97866D1C84A48E00A68A31 /* Validated.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Validated.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC9786891C84A90100A68A31 /* tests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = tests.plist; sourceTree = "<group>"; };
@@ -108,7 +111,7 @@
 		25C79A9F1C7EA40B00F76B49 /* Validated */ = {
 			isa = PBXGroup;
 			children = (
-				25C79AB71C7EA5A800F76B49 /* Validated.swift */,
+				806ACA8E1CB8CF1000A06939 /* Validated.swift */,
 				BCC7034A1C8497B500880C4C /* configuration */,
 			);
 			path = Validated;
@@ -285,7 +288,7 @@
 		25C79A941C7EA40B00F76B49 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0720;
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Benjamin Encz";
 				TargetAttributes = {
@@ -370,7 +373,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				25C79AB81C7EA5A800F76B49 /* Validated.swift in Sources */,
+				806ACA8F1CB8CF1000A06939 /* Validated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -388,6 +391,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				806ACA911CB8CF1000A06939 /* Validated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -395,6 +399,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				806ACA921CB8CF1000A06939 /* Validated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -402,6 +407,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				806ACA901CB8CF1000A06939 /* Validated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -510,6 +516,7 @@
 		25C79AB21C7EA40B00F76B49 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -522,6 +529,7 @@
 		25C79AB31C7EA40B00F76B49 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -549,12 +557,14 @@
 		BC9786641C84A30C00A68A31 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 			};
 			name = Debug;
@@ -562,6 +572,7 @@
 		BC9786651C84A30C00A68A31 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -576,12 +587,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				WATCHOS_DEPLOYMENT_TARGET = 2.1;
 			};
 			name = Debug;
@@ -590,6 +603,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -603,6 +617,7 @@
 		BCC703611C849A9D00880C4C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -613,12 +628,14 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		BCC703621C849A9D00880C4C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Some updates:
- Update to Swift 3 Syntax (2.2 compatible)
- Remove need for explicit wrapped type in generic declarations, ie: `Validated<String, EmptyString>` can now just be `Validated<EmptyString>`
- SPM Support
