### PR TITLE
typealias -> associatedType

### DIFF
--- a/Validated/Validated.swift
+++ b/Validated/Validated.swift
@@ -10,7 +10,7 @@
 /// }
 /// ~~~
 public protocol Validator {
-    typealias WrappedType
+    associatedtype WrappedType
 
     /// Validates if a value of the wrapped type fullfills the requirements of the
     /// wrapper type.


### PR DESCRIPTION
Fixes a Swift 2 warning.

PS - would be awesome to get a new release out - right now the latest release doesn't have @loganmoseley's lower deployment target integrated.

Thank you for all of your work ben! 💯
