### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,14 +4,14 @@
 
 - Migrated to Swift 3.0 - @Ben-G
 
-#2.0.1
+# 2.0.1
 
 *Released: 05/05/2016*
 
 - Lowered iOS Deployment Target to 8.0 - @loganmoseley
 - Update usage of `typealias` to `associatedtype` - @AndrewSB
 
-#2.0
+# 2.0
 *Released: 03/02/2016*
 
 **Breaking API Changes:**
@@ -29,7 +29,7 @@
 - Major Refactoring of `Validated` Type - @dehesa
 - Addition of OSX, tvOS and watchOS targets - @dehesae
 
-#1.0
+# 1.0
 *Released: 02/24/2016*
 
 - Initial Release - @Ben-G


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
